### PR TITLE
Program breadcrumbs

### DIFF
--- a/page_program.php
+++ b/page_program.php
@@ -49,8 +49,8 @@ function remove_page_titles() {
  * pages using the Program template. Retains the current page at the end of the
  * trail
  */
-add_filter('genesis_build_crumbs', 'iac_update_breadcrumbs', 10, 2);
-function iac_update_breadcrumbs($crumbs, $args) {
+add_filter('genesis_build_crumbs', 'iac_program_breadcrumbs', 10, 2);
+function iac_program_breadcrumbs($crumbs, $args) {
     /**
     $uri = "https;//www.theiaconference.com/stage/thursday";
     $label = "Program";
@@ -58,8 +58,8 @@ function iac_update_breadcrumbs($crumbs, $args) {
     $crumb = "<a href=\"{$uri}\">{$label}</a>";
     return $crumb;
     */
-    $crumbs[0] = "Breadcrumb 1";
-    $crumbs[1] = "Breadcrumb 2";
+    $crumbs[0] = "<span class='b1'>Breadcrumb 1</span>";
+    $crumbs[1] = "<span class='b2'>Breadcrumb 2</span>";
     
     return $crumbs;
   } 

--- a/page_program.php
+++ b/page_program.php
@@ -36,40 +36,11 @@ function remove_page_titles() {
   if (is_page('monday') || 
       is_page('tuesday') ||
       is_page('wednesday') ||
-      is_page('thursday') ||
+      is_page('program') ||
       is_page('friday') ||
       is_page('saturday')) {
     remove_action('genesis_entry_header', 'genesis_do_post_title');
   }
-}
-
-/**
- * Add Program entry to navigation even though these pages really nest directly
- * underneath the Thursday schedule page. Clean up after IAC22
- */
-add_filter('genesis_build_crumbs', 'iac_add_program_crumb', 10, 2);
-function iac_add_program_crumb($crumbs, $args) {
-  /**
-   * Alter these two values to alter the resulting output
-   */
-  // Need the page ID directly. Brittle so please take down after IAC22
-  $page_id = 16884;
-  $title = "Program";
-
-  $uri = get_permalink($page_id);
-
-  $home_crumb = array_shift($crumbs);
-  
-  // If we are on a subpage then make sure it doesn't repeat
-  if (count($crumbs) > 1) {
-    array_shift($crumbs);
-  }  
-  $program_crumb = '<a href="' . $uri . '">' . $title . '</a>';
-  
-  array_unshift($crumbs, $program_crumb);
-  array_unshift($crumbs, $home_crumb);
-  
-  return $crumbs;
 }
 
 // Run the Genesis loop.

--- a/page_program.php
+++ b/page_program.php
@@ -44,25 +44,28 @@ function remove_page_titles() {
 }
 
 /**
- * If there is a second record in the breadcrumbs replace it with a link called
- * "Program" that links to the Thursday (first day of main conference) for all
- * pages using the Program template. Retains the current page at the end of the
- * trail
+ * Add Program entry to navigation even though these pages really nest directly
+ * underneath the Thursday schedule page. Clean up after IAC22
  */
-add_filter('genesis_build_crumbs', 'iac_program_breadcrumbs', 10, 2);
-function iac_program_breadcrumbs($crumbs, $args) {
-    /**
-    $uri = "https;//www.theiaconference.com/stage/thursday";
-    $label = "Program";
-    
-    $crumb = "<a href=\"{$uri}\">{$label}</a>";
-    return $crumb;
-    */
-    $crumbs[0] = "<span class='b1'>Breadcrumb 1</span>";
-    $crumbs[1] = "<span class='b2'>Breadcrumb 2</span>";
-    
-    return $crumbs;
-  } 
+add_filter('genesis_build_crumbs', 'iac_add_program_crumb', 10, 2);
+function iac_add_program_crumb($crumbs, $args) {
+  /**
+   * Alter these two values to alter the resulting output
+   */
+  $base_slug = 'thursday';
+  $title = "Program";
+  // Need the page ID directly. Brittle so please take down after IAC22
+  $page_id = 16884;
+  
+  $uri = get_permalink($page_id);
+  
+  $home_crumb = array_shift($crumbs);
+  $program_crumb = '<a href="' . $uri . '">' . $title . '</a>' . $args['sep'];
+  
+  array_unshift($crumbs, $program_crumb);
+  array_unshift($crumbs, $home_crumb);
+  
+  return $crumbs;
 }
 
 // Run the Genesis loop.

--- a/page_program.php
+++ b/page_program.php
@@ -50,7 +50,7 @@ function remove_page_titles() {
  * trail
  */
 add_filter('genesis_build_crumbs', 'iac_update_breadcrumbs', 10, 2);
-function iac_update_breadcrumbs($crumb, $args) {
+function iac_update_breadcrumbs($crumbs, $args) {
     /**
     $uri = "https;//www.theiaconference.com/stage/thursday";
     $label = "Program";

--- a/page_program.php
+++ b/page_program.php
@@ -49,13 +49,19 @@ function remove_page_titles() {
  * pages using the Program template. Retains the current page at the end of the
  * trail
  */
-add_action('genesis_build_crumbs', 'iac_update_breadcrumbs');
-function iac_update_breadcrumbs($crumbs) {
-  if exists($crumbs[1]) {
+add_filter('genesis_build_crumbs', 'iac_update_breadcrumbs');
+function iac_update_breadcrumbs($crumb, $args) {
+    /**
     $uri = "https;//www.theiaconference.com/stage/thursday";
     $label = "Program";
     
-    $crumbs[1] = "<a href=\"{$uri}\">{$label}</a>";
+    $crumb = "<a href=\"{$uri}\">{$label}</a>";
+    return $crumb;
+    */
+    $crumbs[0] = "Breadcrumb 1";
+    $crumbs[1] = "Breadcrumb 2";
+    
+    return $crumbs;
   } 
 }
 

--- a/page_program.php
+++ b/page_program.php
@@ -30,7 +30,7 @@ function theme_prefix_show_notice() {
 add_action('get_header', 'remove_page_titles');
 /**
  * Selectively remove page titles only for the main program schedule using the
- * slugs 
+ * slugs. Should be removed after IAC22 if still using Wordpress.
  */
 function remove_page_titles() {
   if (is_page('monday') || 
@@ -41,6 +41,22 @@ function remove_page_titles() {
       is_page('saturday')) {
     remove_action('genesis_entry_header', 'genesis_do_post_title');
   }
+}
+
+/**
+ * If there is a second record in the breadcrumbs replace it with a link called
+ * "Program" that links to the Thursday (first day of main conference) for all
+ * pages using the Program template. Retains the current page at the end of the
+ * trail
+ */
+add_action('genesis_build_crumbs', 'iac_update_breadcrumbs');
+function iac_update_breadcrumbs($crumbs) {
+  if exists($crumbs[1]) {
+    $uri = "https;//www.theiaconference.com/stage/thursday";
+    $label = "Program";
+    
+    $crumbs[1] = "<a href=\"{$uri}\">{$label}</a>";
+  } 
 }
 
 // Run the Genesis loop.

--- a/page_program.php
+++ b/page_program.php
@@ -52,15 +52,19 @@ function iac_add_program_crumb($crumbs, $args) {
   /**
    * Alter these two values to alter the resulting output
    */
-  $base_slug = 'thursday';
-  $title = "Program";
   // Need the page ID directly. Brittle so please take down after IAC22
   $page_id = 16884;
-  
+  $title = "Program";
+
   $uri = get_permalink($page_id);
-  
+
   $home_crumb = array_shift($crumbs);
-  $program_crumb = '<a href="' . $uri . '">' . $title . '</a>' . $args['sep'];
+  
+  // If we are on a subpage then make sure it doesn't repeat
+  if (count($crumbs) > 1) {
+    array_shift($crumbs);
+  }  
+  $program_crumb = '<a href="' . $uri . '">' . $title . '</a>';
   
   array_unshift($crumbs, $program_crumb);
   array_unshift($crumbs, $home_crumb);

--- a/page_program.php
+++ b/page_program.php
@@ -27,5 +27,21 @@ function theme_prefix_show_notice() {
 		';
 }
 
+add_action('get_header', 'remove_page_titles');
+/**
+ * Selectively remove page titles only for the main program schedule using the
+ * slugs 
+ */
+function remove_page_titles() {
+  if (is_page('monday') || 
+      is_page('tuesday') ||
+      is_page('wednesday') ||
+      is_page('thursday') ||
+      is_page('friday') ||
+      is_page('saturday')) {
+    remove_action('genesis_entry_header', 'genesis_do_post_title');
+  }
+}
+
 // Run the Genesis loop.
 genesis();

--- a/page_program.php
+++ b/page_program.php
@@ -49,7 +49,7 @@ function remove_page_titles() {
  * pages using the Program template. Retains the current page at the end of the
  * trail
  */
-add_filter('genesis_build_crumbs', 'iac_update_breadcrumbs');
+add_filter('genesis_build_crumbs', 'iac_update_breadcrumbs', 10, 2);
 function iac_update_breadcrumbs($crumb, $args) {
     /**
     $uri = "https;//www.theiaconference.com/stage/thursday";


### PR DESCRIPTION
Hide the page title for the Program schedule to simulate dynamic changing of pages. Code is a little brittle as it does rely on the slugs and assumes Thursday to be the canonical "Program" day.